### PR TITLE
Adding github actions and go releaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Create a release
+
+on: 
+  push:
+    tags:
+      - v*
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,31 @@
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+builds:
+- env:
+  - CGO_ENABLED=0
+archives:
+- replacements:
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+brews:
+  - name: incert
+    github:
+      owner: greymatter-io
+      name: homebrew-greymatter
+    description: Ephemeral certificate authority
+    homepage: https://github.com/greymatter-io/incert
+    folder: Formula
+    test: |
+      system "#{bin}/incert version"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joshua-rutherford

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CircleCI](https://circleci.com/gh/greymatter-io/incert.svg?style=svg)](https://circleci.com/gh/greymatter-io/incert)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8e343d15763118d6c09d/maintainability)](https://codeclimate.com/github/greymatter-io/incert/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8e343d15763118d6c09d/test_coverage)](https://codeclimate.com/github/greymatter-io/incert/test_coverage)
+[![Release](https://github.com/greymatter-io/incert/workflows/Create%20a%20release/badge.svg)](https://github.com/greymatter-io/incert/actions)
 
 A command line utility for generating single use certificate authorities and issuing certificates.
 


### PR DESCRIPTION
Github actions will run when a tag is pushed, which will create Github release and push homebrew Formula.

There are a few cleanup that I cannot do:
1. When brew installing from homebrew-greymatter, `acert version` or `incert version` will return empty result (e.g. `incert  ()`) even though `incert issue single -c localhost -a localhost -a localhost.localdomain -e 86000s` creates crt and key files fine. I think it has something to do with the formula that goreleaser creates is different from the formula I created by hand initially (looks as though it just copies the binary and call it a day). So more tinkering is required there:
https://github.com/greymatter-io/homebrew-greymatter/blob/master/Formula/acert.rb
vs.
https://github.com/hiromis/homebrew-core/blob/master/Formula/acert.rb
2. Delete the test release which was built from a tag in a branch (both Github release and homebrew formula) 
3. The whole `VERSION` file mechanism of adding `-dev` and removing it is missing so you will need to tag it manually and discrepancies between the tag and VERSION file will be ignored.

